### PR TITLE
Open-source JxMaps Licence, Minor Updates

### DIFF
--- a/GPSUtilities/GPS Merge/.classpath
+++ b/GPSUtilities/GPS Merge/.classpath
@@ -18,10 +18,10 @@
 	<classpathentry kind="lib" path="C:/devTools/JxMaps/lib/jxmaps-linux64-1.3.1.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/JxMaps/lib/jxmaps-mac-1.3.1.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/JxMaps/lib/jxmaps-win-1.3.1.jar"/>
-	<classpathentry kind="lib" path="C:/devTools/JxMaps/lib/license.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/commons-configuration2-2.2/commons-configuration2-2.2.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/commons-logging-1.2/commons-logging-1.2.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/commons-beanutils-1.9.3/commons-beanutils-1.9.3.jar"/>
 	<classpathentry kind="lib" path="C:/devTools/commons-lang3-3.7/commons-lang3-3.7.jar"/>
+	<classpathentry kind="lib" path="C:/devTools/JxMaps/lib/licence.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/GPSUtilities/GPS Merge/src/svptech/gpsmerge/views/MergeMapView.java
+++ b/GPSUtilities/GPS Merge/src/svptech/gpsmerge/views/MergeMapView.java
@@ -1,13 +1,10 @@
 package svptech.gpsmerge.views;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
 import com.teamdev.jxmaps.ControlPosition;
-import com.teamdev.jxmaps.InfoWindow;
 import com.teamdev.jxmaps.LatLng;
 import com.teamdev.jxmaps.LatLngBounds;
 import com.teamdev.jxmaps.Map;
@@ -29,7 +26,7 @@ public class MergeMapView extends MapView
 	private static List<Marker> allMarkers = new ArrayList<>();
 	private static int markerCounter = 0;
 	
-	private HashMap<Integer, GPSLocation> locations = new HashMap();
+	private HashMap<Integer, GPSLocation> locations = new HashMap<>();
 
 	public MergeMapView()
 	{
@@ -110,17 +107,11 @@ public class MergeMapView extends MapView
 		
 		// All waypoints are plotted. Display the first image as though the user clicked on its marker.
 		GPSLocation firstWaypt = waypoints.get(0);
-		if (firstWaypt!=null)
+		if (firstWaypt != null && firstWaypt.getPhotoFilePathname() != null
+				&& firstWaypt.getPhotoFilePathname().length() > 0)
 		{
-			try
-			{
-				image.setImageFilePathname(firstWaypt.getPhotoFilePathname());
-				firstWaypt.setzIndex(firstWaypt.getTheMarker());
-			} 
-			catch (IOException e)
-			{
-				e.printStackTrace();
-			}
+			image.setImageFilePathname(firstWaypt.getPhotoFilePathname());
+			firstWaypt.setzIndex(firstWaypt.getTheMarker());
 		}
 	}
 
@@ -157,19 +148,12 @@ public class MergeMapView extends MapView
 					@Override
 					public void onEvent(MouseEvent mouseEvent)
 					{
-						try
-						{
-							int markerId = aMarker.hashCode();
-							GPSLocation plotInfo = locations.get(markerId);
-							
-							image.setImageFilePathname(plotInfo.getPhotoFilePathname());
-							plotInfo.setzIndex(aMarker);
-						
-						} 
-						catch (IOException e)
-						{
-							e.printStackTrace();
-						}
+						int markerId = aMarker.hashCode();
+						GPSLocation plotInfo = locations.get(markerId);
+
+						image.setImageFilePathname(plotInfo.getPhotoFilePathname());
+						plotInfo.setzIndex(aMarker);
+
 					}
 				});
 			}

--- a/GPSUtilities/GPS Merge/src/svptech/image/utils/RenderImageFromFile.java
+++ b/GPSUtilities/GPS Merge/src/svptech/image/utils/RenderImageFromFile.java
@@ -64,29 +64,45 @@ public class RenderImageFromFile extends Component
 		return imageFilePathname;
 	}
 
-	public void setImageFilePathname(String imageFilePathname) throws IOException
+	/**
+	 * When a non-null filename of non-zero length is passed, save the filename and
+	 * attempt to render the file as a scaled image on the window. If an obviously bad filename is passed,
+	 * handle as a non-serious error and simply don't paint the image. 
+	 * @param imageFilePathname
+	 */
+	public void setImageFilePathname(String imageFilePathname)
 	{
-		this.imageFilePathname = imageFilePathname;
-
-		img = ImageIO.read(new File(imageFilePathname));
-
-		// The natural size of the image is likely to be wrong, so it needs to be
-		// scaled.
-		// To maintain the aspect, compute the ratio width/height
-		aspect = new Double(img.getWidth()) / new Double(img.getHeight());
-
-		// Make it fit without distortion...
-		computedHeight = new Double(width / aspect).intValue();
-		
-		if (computedHeight>600)
+		if (imageFilePathname!=null && imageFilePathname.length()>0)
 		{
-			computedHeight = 600;
-			width = new Double(computedHeight * aspect).intValue();
+			this.imageFilePathname = imageFilePathname;
+	
+			try
+			{
+				img = ImageIO.read(new File(imageFilePathname));
+				// The natural size of the image is likely to be wrong, so it needs to be
+				// scaled.
+				// To maintain the aspect, compute the ratio width/height
+				aspect = new Double(img.getWidth()) / new Double(img.getHeight());
+	
+				// Make it fit without distortion...
+				computedHeight = new Double(width / aspect).intValue();
+				
+				if (computedHeight>600)
+				{
+					computedHeight = 600;
+					width = new Double(computedHeight * aspect).intValue();
+				}
+	
+				scaledImage = img.getScaledInstance(width, computedHeight, Image.SCALE_DEFAULT);
+				revalidate();
+				repaint();
+			} 
+			catch (IOException e)
+			{
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
 		}
-
-		scaledImage = img.getScaledInstance(width, computedHeight, Image.SCALE_DEFAULT);
-		revalidate();
-		repaint();
 
 	}
 


### PR DESCRIPTION
I received the JxMaps licence file which was named licence.jar instead
of license.jar, which was how the 30 day trial licence was named. I
updated the spelling in the classpath to use the new licence file. Also
some minor validation to allow a gpx file name to be entered when there
are not any picture files specified by the source directory name yet.